### PR TITLE
swap model edit_form permissions to user query factory

### DIFF
--- a/web/app/models/company.py
+++ b/web/app/models/company.py
@@ -1,13 +1,11 @@
 from datetime import datetime
 
-from app import db
-from app.models.utils import ModelMixin, RowActionListMixin
-from app.utils import MyModelView
-
 from flask_login import current_user
 from flask_admin.model.template import EditRowAction, DeleteRowAction
 
-from .user import UserView
+from app import db
+from app.models.utils import ModelMixin, RowActionListMixin
+from app.utils import MyModelView
 
 from app.logger import logger
 
@@ -26,6 +24,15 @@ class Company(db.Model, ModelMixin):
 
     def __repr__(self):
         return self.name
+
+    def _cols(self):
+        return [
+            "name",
+            "locations_per_company",
+            "total_computers",
+            "computers_online",
+            "computers_offline",
+        ]
 
 
 class CompanyView(RowActionListMixin, MyModelView):
@@ -51,22 +58,6 @@ class CompanyView(RowActionListMixin, MyModelView):
             str: text to display in search
         """
         return "Search by all text columns"
-
-    def edit_form(self, obj):
-        form = super(CompanyView, self).edit_form(obj)
-
-        query_res = self.session.query(Company).all()
-
-        permissions = [i[0] for i in UserView.form_choices["asociated_with"]]
-        for company in [i.name for i in query_res]:
-            if company in permissions:
-                break
-            print(f"{company} added")
-            UserView.form_choices["asociated_with"].append((company, f"Company-{company}"))
-        print(f"permissions updated {permissions}")
-
-        form.name.query = query_res
-        return form
 
     def _can_edit(self, model):
         # return True to allow edit

--- a/web/app/models/location.py
+++ b/web/app/models/location.py
@@ -10,8 +10,6 @@ from app import db
 from app.models.utils import ModelMixin, RowActionListMixin
 from app.utils import MyModelView
 
-from .user import UserView
-
 from app.logger import logger
 
 
@@ -30,6 +28,15 @@ class Location(db.Model, ModelMixin):
 
     def __repr__(self):
         return self.name
+
+    def _cols(self):
+        return [
+            "name",
+            "company_name",
+            "computers_per_location",
+            "computers_online",
+            "computers_offline",
+        ]
 
 
 class LocationView(RowActionListMixin, MyModelView):
@@ -56,22 +63,6 @@ class LocationView(RowActionListMixin, MyModelView):
             str: text to display in search
         """
         return "Search by all text columns"
-
-    def edit_form(self, obj):
-        form = super(LocationView, self).edit_form(obj)
-
-        query_res = self.session.query(Location).all()
-
-        permissions = [i[0] for i in UserView.form_choices["asociated_with"]]
-        for location in [i.name for i in query_res]:
-            if location in permissions:
-                break
-            print(f"{location} added")
-            UserView.form_choices["asociated_with"].append((location, f"Location-{location}"))
-        print(f"permissions updated {permissions}")
-
-        form.name.query = query_res
-        return form
 
     def _can_edit(self, model):
         # return True to allow edit

--- a/web/app/models/user.py
+++ b/web/app/models/user.py
@@ -12,7 +12,10 @@ from app import db
 from app.models.utils import ModelMixin, RowActionListMixin
 from app.utils import MyModelView
 
-from config import BaseConfig as CFG
+from .company import Company
+from .location import Location
+
+from logger import logger
 
 
 class User(db.Model, UserMixin, ModelMixin):
@@ -53,6 +56,27 @@ class User(db.Model, UserMixin, ModelMixin):
         return f"<User: {self.username}>"
 
 
+def asociated_with_query_factory():
+    USER_PERMISSIONS = [
+        ("Global-full", "Global-full"),
+        ("Global-view", "Global-view"),
+    ]
+
+    try:
+        locations = db.session.query(Location).all()
+        companies = db.session.query(Company).all()
+
+        for location in locations:
+            USER_PERMISSIONS.append((location, f"Location-{location}"))
+
+        for company in companies:
+            USER_PERMISSIONS.append((company, f"Company-{company}"))
+    except RuntimeError as err:
+        logger.debug("Encountered error most likely during launch. Message {}", err)
+
+    return USER_PERMISSIONS
+
+
 class AnonymousUser(AnonymousUserMixin):
     pass
 
@@ -74,7 +98,7 @@ class UserView(RowActionListMixin, MyModelView):
 
     column_searchable_list = column_list
 
-    form_choices = {"asociated_with": CFG.USER_PERMISSIONS}
+    form_choices = {"asociated_with": asociated_with_query_factory()}
 
     def search_placeholder(self):
         """Defines what text will be displayed in Search input field


### PR DESCRIPTION
Fix for a bug on create/edit form in user associated_with field.

It gives "Not a valid choice" when registering dreiss@luxorhc.com and choose associated_with Company-Luxor-Healthcare. But after it doesn't reproduce every time. So, this bug is not stable.
Changed a way how Associated With field choices are collected:
Before - choices are collected individually in each model (Company, Location) in edit_from to CFG.USER_PERMISSIONS
Now - created query factory in user.py and used directly in form_choices

Also added _cols() to models to get list of useful columns.